### PR TITLE
avoid potentially wrong measurement when clock modified (for linux)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,21 @@
 # only tested in mingw
 PNAME = bfcl
 OBJS = $(PNAME).o ocl_util.o utils.o sha1_16.o aes_128.o ocl_test.o ocl_brute.o
-CFLAGS += -std=c11 -Wall -Werror -O2 -mrdrnd -I$(INTELOCLSDKROOT)/include
-LDFLAGS += -L$(INTELOCLSDKROOT)/lib/x64
+CFLAGS += -std=c11 -Wall -Werror -O2 -mrdrnd
+
+ifeq ($(OS),Windows_NT)
+	CFLAGS += -I$(INTELOCLSDKROOT)/include
+	LDFLAGS += -L$(INTELOCLSDKROOT)/lib/x64
+else
+	# default Intel's Linux OpenCL SDK installation location
+	CFLAGS += /opt/intel/opencl-sdk/include
+	LDFLAGS += -L/opt/intel/opencl-sdk/lib64
+endif
 
 all : $(PNAME)
 
 $(PNAME) : $(OBJS)
-	$(CC) $(LDFLAGS) -o $@ $^ -lOpenCL -static -lmbedcrypto
+	$(CC) $(LDFLAGS) -o $@ $^ -lOpenCL -Wl,-Bstatic -lmbedcrypto -Wl,-Bdynamic
 
 clean :
 	rm $(PNAME) *.o

--- a/bfcl.c
+++ b/bfcl.c
@@ -1,6 +1,7 @@
 
 #include <stdio.h>
 #include <stdint.h>
+#include <string.h>
 #include "utils.h"
 #include "ocl.h"
 #include "ocl_brute.h"

--- a/crypto.h
+++ b/crypto.h
@@ -13,7 +13,7 @@ void aes_init(void);
 void aes_set_key_enc_128(const unsigned char *key);
 void aes_set_key_dec_128(const unsigned char *key);
 
-void aes_encrypt_128(const unsigned char input[16], unsigned char output[16]);
-void aes_decrypt_128(const unsigned char input[16], unsigned char output[16]);
+void aes_encrypt_128(const unsigned char *in, unsigned char *out);
+void aes_decrypt_128(const unsigned char *in, unsigned char *out);
 
-void aes_encrypt_128_bulk(const unsigned char input[16], unsigned char output[16], unsigned len);
+void aes_encrypt_128_bulk(const unsigned char *in, unsigned char *out, unsigned len);

--- a/ocl_brute.c
+++ b/ocl_brute.c
@@ -168,7 +168,7 @@ int ocl_brute_console_id(const cl_uchar *console_id, const cl_uchar *emmc_cid,
 		} else {
 			console_id |= (u64)i << group_bits;
 		}
-		printf("%016"LL"x\n", console_id);
+		printf("%016"LL"x\n", (unsigned long long) console_id);
 		OCL_ASSERT(clSetKernelArg(kernel, 0, sizeof(cl_ulong), &console_id));
 
 		OCL_ASSERT(clEnqueueNDRangeKernel(command_queue, kernel, 1, NULL, &num_items, &local, 0, NULL, NULL));
@@ -177,7 +177,7 @@ int ocl_brute_console_id(const cl_uchar *console_id, const cl_uchar *emmc_cid,
 		OCL_ASSERT(clEnqueueReadBuffer(command_queue, mem_out, CL_TRUE, 0, sizeof(cl_ulong), &out, 0, NULL, NULL));
 		if (out) {
 			get_hp_time(&t1); td = hp_time_diff(&t0, &t1);
-			printf("got a hit: %016"LL"x\n", out);
+			printf("got a hit: %016"LL"x\n", (unsigned long long) out);
 			// also write to a file
 			dump_to_file(emmc_cid ? hexdump(emmc_cid, 16, 0) : hexdump(src0, 16, 0), &out, 8);
 			break;

--- a/ocl_test.c
+++ b/ocl_test.c
@@ -1,5 +1,6 @@
 
 #include <stdio.h>
+#include <string.h>
 #include "utils.h"
 #include "ocl.h"
 #include "crypto.h"
@@ -86,7 +87,7 @@ int ocl_test() {
 	if(cpu_has_rdrand()){
 		// ~190 MB/s @ X230, ~200 without the success check
 		printf("randomize source buffer using RDRAND\n");
-		if (!rdrand_fill((cl_ulong*)buf_in, BUF_SIZE >> 3)) {
+		if (!rdrand_fill((unsigned long long*)buf_in, BUF_SIZE >> 3)) {
 			printf("RDRND failed\n");
 			exit(-1);
 		}

--- a/ocl_util.c
+++ b/ocl_util.c
@@ -1,5 +1,6 @@
 
 #include <stdio.h>
+#include <string.h>
 #include <assert.h>
 #include <malloc.h>
 #include <CL/cl_ext.h>

--- a/utils.c
+++ b/utils.c
@@ -1,3 +1,6 @@
+#ifndef _WIN32
+#define _POSIX_C_SOURCE 199309L
+#endif
 
 #include <stdlib.h>
 #include <stdio.h>
@@ -76,14 +79,14 @@ long long hp_time_diff(LARGE_INTEGER *pt0, LARGE_INTEGER *pt1) {
 
 #else
 
-void get_hp_time(struct timeval *pt) {
-	gettimeofday(pt, NULL);
+void get_hp_time(struct timespec *pt) {
+	clock_gettime(CLOCK_MONOTONIC, pt);
 }
 
-long long hp_time_diff(struct timeval *pt0, struct timeval *pt1) {
-	long long diff = pt1.tv_sec - pt0.tv_sec;
+long long hp_time_diff(struct timespec *pt0, struct timespec *pt1) {
+	long long diff = pt1->tv_sec - pt0->tv_sec;
 	diff *= 1000000;
-	diff += pt1.tv_usec - pt0.tv_usec;
+	diff += (pt1->tv_nsec - pt0->tv_nsec) / 1000;
 	return diff;
 }
 

--- a/utils.h
+++ b/utils.h
@@ -12,8 +12,8 @@ typedef LARGE_INTEGER TimeHP;
 
 #else
 
-#include <sys/time.h>
-typedef struct timeval TimeHP;
+#include <time.h>
+typedef struct timespec TimeHP;
 void get_hp_time(TimeHP *pt);
 
 #define LL "ll"


### PR DESCRIPTION
switch to clock_gettime(CLOCK_MONOTONIC) to avoid inaccuracy when time is changed manually
also supposedly fix linux build issue